### PR TITLE
Remove requirement to pass config_dir

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using System;
 using System.IO;
 
 namespace Auricular.Api {
@@ -12,15 +13,16 @@ namespace Auricular.Api {
             IConfigurationRoot config = builder.Build();
 
             string config_dir = config["config_dir"];
-            Directory.CreateDirectory(config_dir);
-            if (!File.Exists(config_dir + "/appsettings.json") && Directory.Exists(config_dir)) {
-                File.Copy("appsettings.json", config_dir + "/appsettings.json");
+            if (!string.IsNullOrEmpty(config_dir) && !File.Exists(config_dir + "/appsettings.json") && Directory.Exists(config_dir)) {
+                throw new InvalidOperationException("bad config_dir - no appsettings.json file found at " + config_dir);
             }
 
             Host.CreateDefaultBuilder(args)
             .ConfigureAppConfiguration((buildercontext, configbuilder) => {
                 configbuilder.AddConfiguration(config);
-                configbuilder.AddJsonFile(config_dir + "/appsettings.json", optional: true);
+                if (!string.IsNullOrEmpty(config_dir)) {
+                    configbuilder.AddJsonFile(config_dir + "/appsettings.json", optional: true);
+                }
             })
             .ConfigureWebHostDefaults(webBuilder => {
                 webBuilder.UseStartup<Startup>();

--- a/src/Api/Settings/SqliteSettings.cs
+++ b/src/Api/Settings/SqliteSettings.cs
@@ -1,0 +1,5 @@
+namespace Auricular.Api.Settings {
+    public class SqliteSettings {
+        public string DatabaseFilename { get; set; } = "auricular.db";
+    }
+}


### PR DESCRIPTION
If config_dir is passed then it will still be added as a source, but otherwise the default builder will get it from wherever it decides
Added SqliteSettings that is read from the appsettings.json
Database path is now retrieved from the SqliteSettings